### PR TITLE
Support finding key for a tags with additional flags

### DIFF
--- a/find.go
+++ b/find.go
@@ -296,7 +296,7 @@ func generateCursor(result interface{}, paginatedField string, shouldSecondarySo
 	resultStructFieldName := findStructFieldNameByBsonTag(reflect.TypeOf(result), paginatedField)
 	// Check if a tag matching the paginated filed name was found
 	if resultStructFieldName == "" {
-		return "", fmt.Errorf(fmt.Sprintf("paginated field %s not found", paginatedField))
+		return "", fmt.Errorf("paginated field %s not found", paginatedField)
 	}
 
 	// Get the value of the resultStructFieldName

--- a/find.go
+++ b/find.go
@@ -294,7 +294,7 @@ func generateCursor(result interface{}, paginatedField string, shouldSecondarySo
 	}
 	// Find the result struct field name that has a tag matching the paginated filed name
 	resultStructFieldName := findStructFieldNameByBsonTag(reflect.TypeOf(result), paginatedField)
-	// Check if a tag matching the paginated filed name was found
+	// Check if a tag matching the paginated field name was found
 	if resultStructFieldName == "" {
 		return "", fmt.Errorf("paginated field %s not found", paginatedField)
 	}

--- a/find_test.go
+++ b/find_test.go
@@ -15,6 +15,7 @@ import (
 type item struct {
 	ID        bson.ObjectId `json:"id" bson:"_id"`
 	Name      string        `json:"name" bson:"name"`
+	UserID    string        `json:"userId" bson:"userId,omitempty"`
 	CreatedAt time.Time     `json:"createdAt" bson:"createdAt"`
 }
 
@@ -379,7 +380,7 @@ func TestGenerateCursorQuery(t *testing.T) {
 		expectedErr             error
 	}{
 		{
-			"error when wrong nuber of cursor field values specified and shouldSecondarySortOnID is true",
+			"error when wrong number of cursor field values specified and shouldSecondarySortOnID is true",
 			true,
 			"name",
 			"$gt",
@@ -388,7 +389,7 @@ func TestGenerateCursorQuery(t *testing.T) {
 			errors.New("wrong number of cursor field values specified"),
 		},
 		{
-			"error when wrong nuber of cursor field values specified and shouldSecondarySortOnID is false",
+			"error when wrong number of cursor field values specified and shouldSecondarySortOnID is false",
 			false,
 			"_id",
 			"$lt",
@@ -469,7 +470,15 @@ func TestGenerateCursor(t *testing.T) {
 			"_id",
 			false,
 			"",
-			errors.New("the spacified result must be a non nil value"),
+			errors.New("the specified result must be a non nil value"),
+		},
+		{
+			"errors when paginated field not found",
+			item{},
+			"creatorId",
+			false,
+			"",
+			errors.New("paginated field creatorId not found"),
 		},
 	}
 	for _, tc := range cases {
@@ -493,6 +502,12 @@ func TestFindStructFieldNameByBsonTag(t *testing.T) {
 			reflect.TypeOf(item{}),
 			"name",
 			"Name",
+		},
+		{
+			"return struct field name when tag has additional flags",
+			reflect.TypeOf(item{}),
+			"userId",
+			"UserID",
 		},
 		{
 			"return empty struct field name when a non matching bson tag specified",


### PR DESCRIPTION
If the `bson` tag has more than just a key in its value (for example, additional flags, such as`omitempty`), the `findStructFieldNameByBsonTag()` function cannot find the corresponding field name when generating a cursor for a given paginated field. As a result, the application crashes when trying to get the field value.
```
// Find the result struct field name that has a tag matching the paginated filed name
resultStructFieldName := findStructFieldNameByBsonTag(reflect.TypeOf(result), paginatedField)
// Get the value of the resultStructFieldName
paginatedFieldValue := reflect.ValueOf(result).FieldByName(resultStructFieldName).Interface()
```
This PR enables to use an additional bson tag [flags](https://godoc.org/labix.org/v2/mgo/bson#Marshal) without panicing, by parsing the tag and handling the errors.