### PR TITLE
Add support for contexts, instrumented collections and result-pointers

### DIFF
--- a/mgo/find.go
+++ b/mgo/find.go
@@ -272,23 +272,33 @@ func generateCursor(result interface{}, paginatedField string, shouldSecondarySo
 	if result == nil {
 		return "", fmt.Errorf("the specified result must be a non nil value")
 	}
+	// Handle pointer values and reduce number of times reflection is done on the same type.
+	var typ reflect.Type
+	val := reflect.ValueOf(result)
+	if val.Kind() == reflect.Ptr {
+		val = reflect.Indirect(val)
+		typ = val.Type()
+	} else {
+		typ = val.Type()
+	}
+
 	// Find the result struct field name that has a tag matching the paginated filed name
-	resultStructFieldName := mcpbson.FindStructFieldNameByBsonTag(reflect.TypeOf(result), paginatedField)
+	resultStructFieldName := mcpbson.FindStructFieldNameByBsonTag(typ, paginatedField)
 	// Check if a tag matching the paginated field name was found
 	if resultStructFieldName == "" {
 		return "", fmt.Errorf("paginated field %s not found", paginatedField)
 	}
 
 	// Get the value of the resultStructFieldName
-	paginatedFieldValue := reflect.ValueOf(result).FieldByName(resultStructFieldName).Interface()
+	paginatedFieldValue := val.FieldByName(resultStructFieldName).Interface()
 	// Set the cursor data
 	cursorData := make(bson.D, 0, 2)
 	cursorData = append(cursorData, bson.DocElem{Name: paginatedField, Value: paginatedFieldValue})
 	if shouldSecondarySortOnID {
 		// Find the result struct id field name that has a tag matching the _id field name
-		resultStructIDFieldName := mcpbson.FindStructFieldNameByBsonTag(reflect.TypeOf(result), "_id")
+		resultStructIDFieldName := mcpbson.FindStructFieldNameByBsonTag(typ, "_id")
 		// Get the value of the ID field
-		id := reflect.ValueOf(result).FieldByName(resultStructIDFieldName).String()
+		id := val.FieldByName(resultStructIDFieldName).String()
 		cursorData = append(cursorData, bson.DocElem{Name: "_id", Value: id})
 	}
 	// Encode the cursor data into a url safe string

--- a/mgo/find_test.go
+++ b/mgo/find_test.go
@@ -139,7 +139,7 @@ func TestFind(t *testing.T) {
 				Limit:          2,
 				CountTotal:     true,
 			},
-			results: &[]item{},
+			results: &[]*item{},
 			executeCountQuery: func(db *mgo.Database, collectionName string, queries []bson.M) (int, error) {
 				return 2, nil
 			},

--- a/mgo/find_test.go
+++ b/mgo/find_test.go
@@ -28,7 +28,6 @@ func TestFind(t *testing.T) {
 		executeCursorQuery func(db *mgo.Database, collectionName string, query []bson.M, sort []string, limit int, collation *mgo.Collation, results interface{}) error
 		expectedCursor     Cursor
 		expectedErr        error
-		pointer            bool
 	}{
 		{
 			name:               "errors when results is nil",
@@ -130,7 +129,7 @@ func TestFind(t *testing.T) {
 			expectedErr:    errors.New("error"),
 		},
 		{
-			name: "return cursor with next and count also populates results when next and prev not specified",
+			name: "return cursor with next and count also populates results when next and prev not specified (using item pointer)",
 			findParams: FindParams{
 				DB:             &mgo.Database{},
 				CollectionName: "items",

--- a/mongo/find.go
+++ b/mongo/find.go
@@ -76,14 +76,7 @@ type (
 
 // Find executes a find mongo query by using the provided FindParams, fills the passed in result
 // slice pointer and returns a Cursor.
-func Find(p FindParams, results interface{}) (Cursor, error) {
-	ctx := context.Background()
-	return FindWithContext(ctx, p, results)
-}
-
-// FindWithContext executes a find mongo query by using the provided FindParams, fills the passed in result
-// slice pointer and returns a Cursor.
-func FindWithContext(ctx context.Context, p FindParams, results interface{}) (Cursor, error) {
+func Find(ctx context.Context, p FindParams, results interface{}) (Cursor, error) {
 	var err error
 	if results == nil {
 		return Cursor{}, errors.New("results can't be nil")

--- a/mongo/find.go
+++ b/mongo/find.go
@@ -17,10 +17,14 @@ import (
 )
 
 type (
+	Collection interface{
+		CountDocuments(context.Context, interface{}, ...*options.CountOptions) (int64, error)
+		Find(context.Context, interface{}, ...*options.FindOptions) (*mongo.Cursor, error)
+	}
 	// FindParams holds the parameters to be used in a paginated find mongo query that will return a
 	// Cursor.
 	FindParams struct {
-		Collection *mongo.Collection
+		Collection Collection
 
 		// The find query to augment with pagination
 		Query primitive.M
@@ -252,7 +256,7 @@ func decodeCursor(cursor string) (bson.D, error) {
 	return cursorData, err
 }
 
-var executeCountQuery = func(c *mongo.Collection, queries []bson.M) (int, error) {
+var executeCountQuery = func(c Collection, queries []bson.M) (int, error) {
 	ctx := context.Background()
 	count, err := c.CountDocuments(ctx, bson.M{"$and": queries})
 	if err != nil {
@@ -261,7 +265,7 @@ var executeCountQuery = func(c *mongo.Collection, queries []bson.M) (int, error)
 	return int(count), nil
 }
 
-func executeCursorQuery(c *mongo.Collection, query []bson.M, sort bson.D, limit int64, collation *options.Collation, results interface{}) error {
+func executeCursorQuery(c Collection, query []bson.M, sort bson.D, limit int64, collation *options.Collation, results interface{}) error {
 	options := options.Find()
 	options.SetSort(sort)
 	options.SetLimit(limit + 1)

--- a/test/integration/items_store_test.go
+++ b/test/integration/items_store_test.go
@@ -1,4 +1,4 @@
-package mgo
+package integration
 
 import (
 	"os"
@@ -17,15 +17,15 @@ func newStore(t *testing.T) Store {
 	session, err := mgo.Dial(mongoAddr)
 	require.NoError(t, err, "error connecting to mongo")
 	col := session.DB("test_db").C("items")
-	store := NewMongoStore(col)
+	store := NewMgoStore(col)
 	err = store.EnsureIndices()
 	require.NoError(t, err)
 	return store
 }
 
-func createItem(t *testing.T, store Store, name string) Item {
+func createItem(t *testing.T, store Store, name string) *Item {
 	t.Helper()
-	item := Item{
+	item := &Item{
 		ID:        "",
 		Name:      name,
 		CreatedAt: time.Now(),


### PR DESCRIPTION
This PR fixes some issues I found while implementing pagination for our service.
These changes are made to the `mongo` pagination only.
- Adds a `Collection` interface so that we rely on functions present and not the exact type `*mongo.Collection`. This allows us to use instrumented collections as well.
- Changes the `Find` function so that it also takes a context so that we can use non-default context, which is useful for e.g. timeouts. To do this I also changed the signatures of some private functions so that they take a context as well.

This change is made to both `mgo` and `mongo` pagination.
- Allows generateCursor to handle pointers. The `result` parameter can now be a pointer. Also the number of times reflection is used on the same object is reduced, which could be good since reflection is typically a quite heavy operation.

I also added the usage of a pointer in the unit-test suite (`TestFind` specifically) and modified so that the integration test uses pointers only.

Also, I moved the tests from the `test/integration/mgo` folder to `test/integration` folder so that nothing has to be run separately; the integration tests will now be run by the `TestMain` function.