### PR TITLE
Update readme with more index details

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Where the items collection is indexed:
 mgo.Index{
     Name: "cover_find_by_name",
     Key: []string{
-        "name",
+		// _id is required in the index' key as we secondary sort on _id when the paginated field is not _id
+		Key:    []string{"name", "_id"},
     },
     Unique: false,
     Collation: &mgo.Collation{

--- a/test/integration/mgo_items_store.go
+++ b/test/integration/mgo_items_store.go
@@ -85,9 +85,8 @@ func (m *mgoStore) find(query interface{}, next string, previous string, limit i
 func (m *mgoStore) EnsureIndices() error {
 	err := m.col.EnsureIndex(mgo.Index{
 		Name: "cover_find_by_name",
-		Key: []string{
-			"name",
-		},
+		// _id is required in the index' key as we secondary sort on _id when the paginated field is not _id
+		Key:    []string{"name", "_id"},
 		Unique: false,
 		Collation: &mgo.Collation{
 			Locale:   "en",


### PR DESCRIPTION
Updating the readme and the mgo integration test to talk about _id which has to be part of the index.

```
> db.items.createIndex({ name: 1, _id: 1 })
{
        "createdCollectionAutomatically" : false,
        "numIndexesBefore" : 2,
        "numIndexesAfter" : 3,
        "ok" : 1
}

> db.items.insert({"name": "Etienne3"})
> db.items.insert({"name": "Etienne2"})
> db.items.insert({"name": "Etienne1"})
> db.items.insert({"name": "Etienne1"})
> db.items.insert({"name": "Etienne2"})
> db.items.insert({"name": "Etienne3"})

> db.items.find( { name: { $regex: /enne/, $options: "si" } } ).sort( { name: 1, _id: 1 } )
{ "_id" : ObjectId("602d751d118e3d88b0e43437"), "name" : "Etienne1" }
{ "_id" : ObjectId("602d75ab1fd17ad69d6482d7"), "name" : "Etienne1" }
{ "_id" : ObjectId("602d7505118e3d88b0e43435"), "name" : "Etienne2" }
{ "_id" : ObjectId("602d75ad1fd17ad69d6482d8"), "name" : "Etienne2" }
{ "_id" : ObjectId("602d7507118e3d88b0e43436"), "name" : "Etienne3" }
{ "_id" : ObjectId("602d75b11fd17ad69d6482d9"), "name" : "Etienne3" }

> db.items.find( { name: { $regex: /enne/, $options: "si" } } ).sort( { name: 1, _id: 1 } ).explain()
{
        "queryPlanner" : {
                "plannerVersion" : 1,
                "namespace" : "test.items",
                "indexFilterSet" : false,
                "parsedQuery" : {
                        "name" : {
                                "$regex" : "enne",
                                "$options" : "si"
                        }
                },
                "queryHash" : "9461B497",
                "planCacheKey" : "5727C12B",
                "winningPlan" : {
                        "stage" : "FETCH",
                        "inputStage" : {
                                "stage" : "IXSCAN",
                                "filter" : {
                                        "name" : {
                                                "$regex" : "enne",
                                                "$options" : "si"
                                        }
                                },
                                "keyPattern" : {
                                        "name" : 1,
                                        "_id" : 1
                                },
                                "indexName" : "name_1__id_1",
                                "isMultiKey" : false,
                                "multiKeyPaths" : {
                                        "name" : [ ],
                                        "_id" : [ ]
                                },
                                "isUnique" : false,
                                "isSparse" : false,
                                "isPartial" : false,
                                "indexVersion" : 2,
                                "direction" : "forward",
                                "indexBounds" : {
                                        "name" : [
                                                "[\"\", {})",
                                                "[/enne/si, /enne/si]"
                                        ],
                                        "_id" : [
                                                "[MinKey, MaxKey]"
                                        ]
                                }
                        }
                },
                "rejectedPlans" : [ ]
        },
        "serverInfo" : {
                "host" : "6be5cb87c8d5",
                "port" : 27017,
                "version" : "4.2.12",
                "gitVersion" : "5593fd8e33b60c75802edab304e23998fa0ce8a5"
        },
        "ok" : 1
}
```