### PR TITLE
feat: support multiple paginated fields

### DIFF
--- a/bson/bson.go
+++ b/bson/bson.go
@@ -30,7 +30,7 @@ func GenerateCursorQuery(paginatedFields []string, comparisonOps []string, curso
 				{paginatedFields[0]: map[string]interface{}{comparisonOps[0]: cursorFieldValues[0]}},
 				{"$and": []map[string]interface{}{
 					{paginatedFields[0]: map[string]interface{}{rangeOp: cursorFieldValues[0]}},
-					{"_id": map[string]interface{}{comparisonOps[1]: cursorFieldValues[1]}},
+					{"_id": map[string]interface{}{comparisonOps[0]: cursorFieldValues[1]}},
 				}},
 			}}
 		} else {
@@ -41,7 +41,7 @@ func GenerateCursorQuery(paginatedFields []string, comparisonOps []string, curso
 					{paginatedFields[i]: map[string]interface{}{comparisonOps[i]: cursorFieldValues[i]}},
 					{"$and": []map[string]interface{}{
 						{paginatedFields[i]: map[string]interface{}{rangeOp: cursorFieldValues[i]}},
-						{"_id": map[string]interface{}{comparisonOps[len(comparisonOps)-1]: cursorFieldValues[len(cursorFieldValues)-1]}},
+						{"_id": map[string]interface{}{comparisonOps[i]: cursorFieldValues[len(cursorFieldValues)-1]}},
 					}},
 				}}
 			}

--- a/bson/bson.go
+++ b/bson/bson.go
@@ -6,29 +6,49 @@ import (
 )
 
 // GenerateCursorQuery generates and returns a cursor range query
-func GenerateCursorQuery(shouldSecondarySortOnID bool, paginatedField string, comparisonOp string, cursorFieldValues []interface{}) (map[string]interface{}, error) {
+func GenerateCursorQuery(paginatedFields []string, comparisonOps []string, cursorFieldValues []interface{}) (map[string]interface{}, error) {
 	var query map[string]interface{}
-	if (shouldSecondarySortOnID && len(cursorFieldValues) != 2) ||
-		(!shouldSecondarySortOnID && len(cursorFieldValues) != 1) {
+
+	if len(paginatedFields) != len(cursorFieldValues) {
 		return nil, errors.New("wrong number of cursor field values specified")
 	}
 
-	if comparisonOp != "$lt" && comparisonOp != "$gt" {
-		return nil, errors.New("invalid comparison operator specified: only $lt and $gt are allowed")
+	if len(comparisonOps) != len(cursorFieldValues) {
+		return nil, errors.New("wrong number of comparison operators specified")
 	}
 
-	rangeOp := fmt.Sprintf("%se", comparisonOp)
+	for i := range comparisonOps {
+		if comparisonOps[i] != "$lt" && comparisonOps[i] != "$gt" {
+			return nil, errors.New("invalid comparison operator specified: only $lt and $gt are allowed")
+		}
+	}
 
-	if shouldSecondarySortOnID {
-		query = map[string]interface{}{"$or": []map[string]interface{}{
-			{paginatedField: map[string]interface{}{comparisonOp: cursorFieldValues[0]}},
-			{"$and": []map[string]interface{}{
-				{paginatedField: map[string]interface{}{rangeOp: cursorFieldValues[0]}},
-				{"_id": map[string]interface{}{comparisonOp: cursorFieldValues[1]}},
-			}},
-		}}
+	if len(paginatedFields) > 1 {
+		if len(paginatedFields) == 2 {
+			rangeOp := fmt.Sprintf("%se", comparisonOps[0])
+			query = map[string]interface{}{"$or": []map[string]interface{}{
+				{paginatedFields[0]: map[string]interface{}{comparisonOps[0]: cursorFieldValues[0]}},
+				{"$and": []map[string]interface{}{
+					{paginatedFields[0]: map[string]interface{}{rangeOp: cursorFieldValues[0]}},
+					{"_id": map[string]interface{}{comparisonOps[1]: cursorFieldValues[1]}},
+				}},
+			}}
+		} else {
+			conditions := make([]map[string]interface{}, len(paginatedFields)-1)
+			for i := 0; i < len(paginatedFields)-1; i++ {
+				rangeOp := fmt.Sprintf("%se", comparisonOps[i])
+				conditions[i] = map[string]interface{}{"$or": []map[string]interface{}{
+					{paginatedFields[i]: map[string]interface{}{comparisonOps[i]: cursorFieldValues[i]}},
+					{"$and": []map[string]interface{}{
+						{paginatedFields[i]: map[string]interface{}{rangeOp: cursorFieldValues[i]}},
+						{"_id": map[string]interface{}{comparisonOps[len(comparisonOps)-1]: cursorFieldValues[len(cursorFieldValues)-1]}},
+					}},
+				}}
+			}
+			query = map[string]interface{}{"$and": conditions}
+		}
 	} else {
-		query = map[string]interface{}{paginatedField: map[string]interface{}{comparisonOp: cursorFieldValues[0]}}
+		query = map[string]interface{}{"_id": map[string]interface{}{comparisonOps[0]: cursorFieldValues[0]}}
 	}
 	return query, nil
 }

--- a/bson/bson_test.go
+++ b/bson/bson_test.go
@@ -65,7 +65,7 @@ func TestGenerateCursorQuery(t *testing.T) {
 		{
 			"return appropriate cursor when sorting on multiple fields",
 			[]string{"name", "createdAt", "_id"},
-			[]string{"$lt", "$lt", "$lt"},
+			[]string{"$lt", "$gt", "$lt"},
 			[]interface{}{"test item", "2024", "123"},
 			map[string]interface{}{"$and": []map[string]interface{}{
 				{"$or": []map[string]interface{}{
@@ -74,10 +74,10 @@ func TestGenerateCursorQuery(t *testing.T) {
 						{"name": map[string]interface{}{"$lte": "test item"}},
 						{"_id": map[string]interface{}{"$lt": "123"}}}}}},
 				{"$or": []map[string]interface{}{
-					{"createdAt": map[string]interface{}{"$lt": "2024"}},
+					{"createdAt": map[string]interface{}{"$gt": "2024"}},
 					{"$and": []map[string]interface{}{
-						{"createdAt": map[string]interface{}{"$lte": "2024"}},
-						{"_id": map[string]interface{}{"$lt": "123"}}}}}}}},
+						{"createdAt": map[string]interface{}{"$gte": "2024"}},
+						{"_id": map[string]interface{}{"$gt": "123"}}}}}}}},
 			nil,
 		},
 	}

--- a/bson/bson_test.go
+++ b/bson/bson_test.go
@@ -9,46 +9,41 @@ import (
 
 func TestGenerateCursorQuery(t *testing.T) {
 	var cases = []struct {
-		name                    string
-		shouldSecondarySortOnID bool
-		paginatedField          string
-		comparisonOp            string
-		cursorFieldValues       []interface{}
-		expectedQuery           map[string]interface{}
-		expectedErr             error
+		name              string
+		paginatedFields   []string
+		comparisonOps     []string
+		cursorFieldValues []interface{}
+		expectedQuery     map[string]interface{}
+		expectedErr       error
 	}{
 		{
-			"error when wrong number of cursor field values specified and shouldSecondarySortOnID is true",
-			true,
-			"name",
-			"$gt",
+			"error when wrong number of cursor field values specified",
+			[]string{"name", "_id"},
+			[]string{"$gt", "$gt"},
 			[]interface{}{"abc"},
 			nil,
 			errors.New("wrong number of cursor field values specified"),
 		},
 		{
-			"error when wrong number of cursor field values specified and shouldSecondarySortOnID is false",
-			false,
-			"_id",
-			"$lt",
-			[]interface{}{},
+			"error when wrong number of comparison operators specified",
+			[]string{"name", "_id"},
+			[]string{"$gt"},
+			[]interface{}{"abc", "abc"},
 			nil,
-			errors.New("wrong number of cursor field values specified"),
+			errors.New("wrong number of comparison operators specified"),
 		},
 		{
 			"error when an invalid comparison operator is specified",
-			false,
-			"name",
-			"$blabla",
+			[]string{"_id"},
+			[]string{"$blabla"},
 			[]interface{}{"abc"},
 			nil,
 			errors.New("invalid comparison operator specified: only $lt and $gt are allowed"),
 		},
 		{
-			"return appropriate cursor query when shouldSecondarySortOnID is true",
-			true,
-			"name",
-			"$gt",
+			"return appropriate cursor query when sorting on single field",
+			[]string{"name", "_id"},
+			[]string{"$gt", "$gt"},
 			[]interface{}{"test item", "123"},
 			map[string]interface{}{"$or": []map[string]interface{}{
 				{"name": map[string]interface{}{"$gt": "test item"}},
@@ -60,18 +55,35 @@ func TestGenerateCursorQuery(t *testing.T) {
 			nil,
 		},
 		{
-			"return appropriate cursor query when shouldSecondarySortOnID is false",
-			false,
-			"_id",
-			"$lt",
+			"return appropriate cursor query when there is no paginated field",
+			[]string{"_id"},
+			[]string{"$lt"},
 			[]interface{}{"123"},
 			map[string]interface{}{"_id": map[string]interface{}{"$lt": "123"}},
+			nil,
+		},
+		{
+			"return appropriate cursor when sorting on multiple fields",
+			[]string{"name", "createdAt", "_id"},
+			[]string{"$lt", "$lt", "$lt"},
+			[]interface{}{"test item", "2024", "123"},
+			map[string]interface{}{"$and": []map[string]interface{}{
+				{"$or": []map[string]interface{}{
+					{"name": map[string]interface{}{"$lt": "test item"}},
+					{"$and": []map[string]interface{}{
+						{"name": map[string]interface{}{"$lte": "test item"}},
+						{"_id": map[string]interface{}{"$lt": "123"}}}}}},
+				{"$or": []map[string]interface{}{
+					{"createdAt": map[string]interface{}{"$lt": "2024"}},
+					{"$and": []map[string]interface{}{
+						{"createdAt": map[string]interface{}{"$lte": "2024"}},
+						{"_id": map[string]interface{}{"$lt": "123"}}}}}}}},
 			nil,
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			query, err := GenerateCursorQuery(tc.shouldSecondarySortOnID, tc.paginatedField, tc.comparisonOp, tc.cursorFieldValues)
+			query, err := GenerateCursorQuery(tc.paginatedFields, tc.comparisonOps, tc.cursorFieldValues)
 			require.Equal(t, tc.expectedQuery, query)
 			require.Equal(t, tc.expectedErr, err)
 		})

--- a/mgo/find.go
+++ b/mgo/find.go
@@ -102,10 +102,6 @@ func Find(p FindParams, results interface{}) (Cursor, error) {
 	}
 	p = ensureMandatoryParams(p)
 
-	if p.PaginatedField == "" {
-		p.PaginatedField = "_id"
-		p.Collation = nil
-	}
 	var numPaginatedFields int
 	if p.PaginatedFields != nil && len(p.PaginatedFields) > 0 {
 		numPaginatedFields = len(p.PaginatedFields)
@@ -253,18 +249,21 @@ func generateComparisonOps(p FindParams) []string {
 	}
 	return comparisonOps
 }
+
 func ensureMandatoryParams(p FindParams) FindParams {
 	if p.PaginatedField == "" {
 		p.PaginatedField = "_id"
 		p.Collation = nil
 	}
 	if p.PaginatedFields == nil || len(p.PaginatedFields) == 0 {
-		if p.PaginatedField == "" {
+		if p.PaginatedField == "_id" {
 			p.PaginatedFields = []string{"_id"}
-			p.Collation = nil
 		} else {
 			p.PaginatedFields = []string{p.PaginatedField, "_id"}
 		}
+	} else if p.PaginatedFields[len(p.PaginatedFields)-1] != "_id" {
+		p.PaginatedFields = append(p.PaginatedFields, "_id")
+		p.SortOrders = append(p.SortOrders, 1)
 	}
 	if p.SortOrders == nil || len(p.SortOrders) == 0 {
 		p.SortOrders = []int{}

--- a/mgo/find.go
+++ b/mgo/find.go
@@ -63,6 +63,9 @@ type (
 		// Whether or not to include total count of documents matching filter in the cursor
 		// Specifying true makes an additionnal query
 		CountTotal bool
+		// The names of multiple fields being paginated and sorted on
+		PaginatedFields []string
+		SortOrders      []int
 	}
 
 	// Cursor holds the pagination data about the find mongo query that was performed.
@@ -97,12 +100,18 @@ func Find(p FindParams, results interface{}) (Cursor, error) {
 	if results == nil {
 		return Cursor{}, errors.New("results can't be nil")
 	}
+	p = ensureMandatoryParams(p)
 
 	if p.PaginatedField == "" {
 		p.PaginatedField = "_id"
 		p.Collation = nil
 	}
-	shouldSecondarySortOnID := p.PaginatedField != "_id"
+	var numPaginatedFields int
+	if p.PaginatedFields != nil && len(p.PaginatedFields) > 0 {
+		numPaginatedFields = len(p.PaginatedFields)
+	} else {
+		numPaginatedFields = 1
+	}
 
 	if p.DB == nil {
 		return Cursor{}, errors.New("DB can't be nil")
@@ -112,24 +121,17 @@ func Find(p FindParams, results interface{}) (Cursor, error) {
 		return Cursor{}, errors.New("a limit of at least 1 is required")
 	}
 
-	nextCursorValues, err := parseCursor(p.Next, shouldSecondarySortOnID)
+	nextCursorValues, err := parseCursor(p.Next, numPaginatedFields)
 	if err != nil {
 		return Cursor{}, &CursorError{fmt.Errorf("next cursor parse failed: %s", err)}
 	}
 
-	previousCursorValues, err := parseCursor(p.Previous, shouldSecondarySortOnID)
+	previousCursorValues, err := parseCursor(p.Previous, numPaginatedFields)
 	if err != nil {
 		return Cursor{}, &CursorError{fmt.Errorf("previous cursor parse failed: %s", err)}
 	}
 
-	// Figure out the sort direction and comparison operator that will be used in the augmented query
-	sortAsc := (!p.SortAscending && p.Previous != "") || (p.SortAscending && p.Previous == "")
-	comparisonOp := "$gt"
-	sortDir := ""
-	if !sortAsc {
-		comparisonOp = "$lt"
-		sortDir = "-"
-	}
+	comparisonOps := generateComparisonOps(p)
 
 	// Augment the specified find query with cursor data
 	queries := []bson.M{p.Query}
@@ -152,7 +154,7 @@ func Find(p FindParams, results interface{}) (Cursor, error) {
 			cursorValues = previousCursorValues
 		}
 		var cursorQuery bson.M
-		cursorQuery, err = mcpbson.GenerateCursorQuery(shouldSecondarySortOnID, p.PaginatedField, comparisonOp, cursorValues)
+		cursorQuery, err = mcpbson.GenerateCursorQuery(p.PaginatedFields, comparisonOps, cursorValues)
 		if err != nil {
 			return Cursor{}, err
 		}
@@ -161,13 +163,12 @@ func Find(p FindParams, results interface{}) (Cursor, error) {
 
 	// Setup the sort query
 	var sort []string
-	if shouldSecondarySortOnID {
-		sort = []string{
-			fmt.Sprintf("%s%s", sortDir, p.PaginatedField),
-			fmt.Sprintf("%s%s", sortDir, "_id"),
+	for i := range p.PaginatedFields {
+		sortDir := ""
+		if p.SortOrders[i] == -1 {
+			sortDir = "-"
 		}
-	} else {
-		sort = []string{fmt.Sprintf("%s%s", sortDir, "_id")}
+		sort = append(sort, fmt.Sprintf("%s%s", sortDir, p.PaginatedFields[i]))
 	}
 
 	// Execute the augmented query, get an additional element to see if there's another page
@@ -206,7 +207,7 @@ func Find(p FindParams, results interface{}) (Cursor, error) {
 		// Generate the previous cursor
 		if hasPrevious {
 			firstResult := resultsVal.Index(0).Interface()
-			previousCursor, err = generateCursor(firstResult, p.PaginatedField, shouldSecondarySortOnID)
+			previousCursor, err = generateCursor(firstResult, p.PaginatedFields)
 			if err != nil {
 				return Cursor{}, fmt.Errorf("could not create a previous cursor: %s", err)
 			}
@@ -215,7 +216,7 @@ func Find(p FindParams, results interface{}) (Cursor, error) {
 		// Generate the next cursor
 		if hasNext {
 			lastResult := resultsVal.Index(resultsVal.Len() - 1).Interface()
-			nextCursor, err = generateCursor(lastResult, p.PaginatedField, shouldSecondarySortOnID)
+			nextCursor, err = generateCursor(lastResult, p.PaginatedFields)
 			if err != nil {
 				return Cursor{}, fmt.Errorf("could not create a next cursor: %s", err)
 			}
@@ -237,29 +238,67 @@ func Find(p FindParams, results interface{}) (Cursor, error) {
 	return cursor, nil
 }
 
-var parseCursor = func(cursor string, shouldSecondarySortOnID bool) ([]interface{}, error) {
-	cursorValues := make([]interface{}, 0, 2)
+func generateComparisonOps(p FindParams) []string {
+	comparisonOps := make([]string, 0, len(p.SortOrders))
+	for i := range p.SortOrders {
+		// Figure out the sort direction and comparison operator that will be used in the augmented query
+		sortAsc := (p.SortOrders[i] == -1 && p.Previous != "") || (p.SortOrders[i] == 1 && p.Previous == "")
+		if sortAsc {
+			comparisonOps = append(comparisonOps, "$gt")
+			p.SortOrders[i] = 1
+		} else {
+			comparisonOps = append(comparisonOps, "$lt")
+			p.SortOrders[i] = -1
+		}
+	}
+	return comparisonOps
+}
+func ensureMandatoryParams(p FindParams) FindParams {
+	if p.PaginatedField == "" {
+		p.PaginatedField = "_id"
+		p.Collation = nil
+	}
+	if p.PaginatedFields == nil || len(p.PaginatedFields) == 0 {
+		if p.PaginatedField == "" {
+			p.PaginatedFields = []string{"_id"}
+			p.Collation = nil
+		} else {
+			p.PaginatedFields = []string{p.PaginatedField, "_id"}
+		}
+	}
+	if p.SortOrders == nil || len(p.SortOrders) == 0 {
+		p.SortOrders = []int{}
+		if p.SortAscending {
+			for i := 0; i < len(p.PaginatedFields); i++ {
+				p.SortOrders = append(p.SortOrders, 1)
+			}
+		} else {
+			for i := 0; i < len(p.PaginatedFields); i++ {
+				p.SortOrders = append(p.SortOrders, -1)
+			}
+		}
+	}
+	return p
+}
+
+var parseCursor = func(cursor string, numPaginatedFields int) ([]interface{}, error) {
+	cursorValues := make([]interface{}, 0, numPaginatedFields)
 	if cursor != "" {
 		parsedCursor, err := decodeCursor(cursor)
 		if err != nil {
 			return nil, err
 		}
-		var id interface{}
-		if shouldSecondarySortOnID {
-			if len(parsedCursor) != 2 {
-				return nil, errors.New("expecting a cursor with two elements")
-			}
-			paginatedFieldValue := parsedCursor[0].Value
-			id = parsedCursor[1].Value
-			cursorValues = append(cursorValues, paginatedFieldValue)
-		} else {
-			if len(parsedCursor) != 1 {
+		if len(parsedCursor) != numPaginatedFields {
+			if numPaginatedFields == 1 {
 				return nil, errors.New("expecting a cursor with a single element")
 			}
-			id = parsedCursor[0].Value
+			return nil, fmt.Errorf("expecting a cursor with %d elements", numPaginatedFields)
 		}
-		cursorValues = append(cursorValues, id)
+		for _, obj := range parsedCursor {
+			cursorValues = append(cursorValues, obj.Value)
+		}
 	}
+
 	return cursorValues, nil
 }
 
@@ -286,7 +325,7 @@ var executeCursorQuery = func(db MgoDb, collectionName string, query []bson.M, s
 	return db.C(collectionName).Find(bson.M{"$and": query}).Sort(sort...).Collation(collation).Limit(limit + 1).All(results)
 }
 
-func generateCursor(result interface{}, paginatedField string, shouldSecondarySortOnID bool) (string, error) {
+func generateCursor(result interface{}, paginatedFields []string) (string, error) {
 	if result == nil {
 		return "", fmt.Errorf("the specified result must be a non nil value")
 	}
@@ -314,23 +353,26 @@ func generateCursor(result interface{}, paginatedField string, shouldSecondarySo
 	if err != nil {
 		return "", err
 	}
-	paginatedFieldValue := recordAsMap[paginatedField]
-	if paginatedFieldValue == nil {
-		return "", fmt.Errorf("paginated field %s not found", paginatedField)
-	}
+
 	// Set the cursor data
-	cursorData := make(bson.D, 0, 2)
-	cursorData = append(cursorData, bson.DocElem{Name: paginatedField, Value: paginatedFieldValue})
-	if shouldSecondarySortOnID {
-		// Get the value of the ID field
-		id := recordAsMap["_id"]
-		cursorData = append(cursorData, bson.DocElem{Name: "_id", Value: id})
+	cursorData := make(bson.D, 0, len(paginatedFields))
+	for i := range paginatedFields {
+		paginatedFieldValue := recordAsMap[paginatedFields[i]]
+		if paginatedFieldValue == nil {
+			return "", fmt.Errorf("paginated field %s not found", paginatedFields[i])
+		}
+		cursorData = append(cursorData, bson.DocElem{Name: paginatedFields[i], Value: paginatedFieldValue})
 	}
 	// Encode the cursor data into a url safe string
 	cursor, err := encodeCursor(cursorData)
 	if err != nil {
 		return "", fmt.Errorf("failed to encode cursor using %v: %s", cursorData, err)
 	}
+	paginatedFieldValue := recordAsMap[paginatedFields[0]]
+	if paginatedFieldValue == nil {
+		return "", fmt.Errorf("paginated field %s not found", paginatedFields[0])
+	}
+
 	return cursor, nil
 }
 

--- a/mgo/find.go
+++ b/mgo/find.go
@@ -63,9 +63,10 @@ type (
 		// Whether or not to include total count of documents matching filter in the cursor
 		// Specifying true makes an additionnal query
 		CountTotal bool
-		// The names of multiple fields being paginated and sorted on
+		// The names of multiple fields being paginated and sorted on. Takes precedence over PaginatedField
 		PaginatedFields []string
-		SortOrders      []int
+		// The sort orders corresponding to PaginatedFields. Each value must be either 1 or -1
+		SortOrders []int
 	}
 
 	// Cursor holds the pagination data about the find mongo query that was performed.
@@ -255,7 +256,7 @@ func ensureMandatoryParams(p FindParams) FindParams {
 		p.PaginatedField = "_id"
 		p.Collation = nil
 	}
-	if p.PaginatedFields == nil || len(p.PaginatedFields) == 0 {
+	if len(p.PaginatedFields) == 0 {
 		if p.PaginatedField == "_id" {
 			p.PaginatedFields = []string{"_id"}
 		} else {
@@ -265,7 +266,7 @@ func ensureMandatoryParams(p FindParams) FindParams {
 		p.PaginatedFields = append(p.PaginatedFields, "_id")
 		p.SortOrders = append(p.SortOrders, 1)
 	}
-	if p.SortOrders == nil || len(p.SortOrders) == 0 {
+	if len(p.SortOrders) == 0 {
 		p.SortOrders = []int{}
 		if p.SortAscending {
 			for i := 0; i < len(p.PaginatedFields); i++ {

--- a/mgo/find_test.go
+++ b/mgo/find_test.go
@@ -249,9 +249,8 @@ func TestFind(t *testing.T) {
 				return nil
 			},
 			expectedCursor: Cursor{
-				Previous: "",
-				// Next:        "FgAAAAdfaWQAKt31M-gVSd52lssEAA",
-				Next:        "JwAAAAdfaWQAKt31M-gVSd52lssEB19pZAAq3fUz6BVJ3naWywQA",
+				Previous:    "",
+				Next:        "FgAAAAdfaWQAKt31M-gVSd52lssEAA",
 				HasPrevious: false,
 				HasNext:     true,
 				Count:       0,

--- a/mgo/find_test.go
+++ b/mgo/find_test.go
@@ -249,8 +249,9 @@ func TestFind(t *testing.T) {
 				return nil
 			},
 			expectedCursor: Cursor{
-				Previous:    "",
-				Next:        "FgAAAAdfaWQAKt31M-gVSd52lssEAA",
+				Previous: "",
+				// Next:        "FgAAAAdfaWQAKt31M-gVSd52lssEAA",
+				Next:        "JwAAAAdfaWQAKt31M-gVSd52lssEB19pZAAq3fUz6BVJ3naWywQA",
 				HasPrevious: false,
 				HasNext:     true,
 				Count:       0,
@@ -295,49 +296,49 @@ func TestParseCursor(t *testing.T) {
 	var cases = []struct {
 		name                      string
 		cursor                    string
-		shouldSecondarySortOnID   bool
+		numPaginatedFields        int
 		expectedCursorFieldValues []interface{}
 		expectedErr               error
 	}{
 		{
 			"return appropriate cursor field values when shouldSecondarySortOnID is true",
 			"LAAAAAJuYW1lAAwAAAB0ZXN0IGl0ZW0gMQAHX2lkABrd9TPoFUnedpbLBAA",
-			true,
+			2,
 			[]interface{}{"test item 1", bson.ObjectIdHex("1addf533e81549de7696cb04")},
 			nil,
 		},
 		{
 			"return appropriate cursor field values when shouldSecondarySortOnID is false",
 			"FgAAAAdfaWQAWt31M-gVSd52lssEAA",
-			false,
+			1,
 			[]interface{}{bson.ObjectIdHex("5addf533e81549de7696cb04")},
 			nil,
 		},
 		{
 			"errors when decode fails",
 			"XXXXXaGVsbG8=",
-			true,
+			2,
 			nil,
 			base64.CorruptInputError(12),
 		},
 		{
 			"errors when expecting cursor with 2 elements and only 1 present",
 			"FgAAAAdfaWQAWt31M-gVSd52lssEAA",
-			true,
+			2,
 			nil,
-			errors.New("expecting a cursor with two elements"),
+			errors.New("expecting a cursor with 2 elements"),
 		},
 		{
 			"errors when expecting cursor with 1 elements and only 2 present",
 			"LwAAAAJuYW1lAAoAAAB0ZXN0IGl0ZW0AAl9pZAANAAAAWt31M-gVSd52lssEAAA",
-			false,
+			1,
 			nil,
 			errors.New("expecting a cursor with a single element"),
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cursorFieldValues, err := parseCursor(tc.cursor, tc.shouldSecondarySortOnID)
+			cursorFieldValues, err := parseCursor(tc.cursor, tc.numPaginatedFields)
 			require.Equal(t, tc.expectedCursorFieldValues, cursorFieldValues)
 			require.Equal(t, tc.expectedErr, err)
 		})
@@ -378,6 +379,7 @@ func TestGenerateCursor(t *testing.T) {
 		name                    string
 		result                  interface{}
 		paginatedField          string
+		paginatedFields         []string
 		shouldSecondarySortOnID bool
 		encodeCursor            func(cursorData bson.D) (string, error)
 		expectedCursor          string
@@ -387,6 +389,7 @@ func TestGenerateCursor(t *testing.T) {
 			"return the generated cursor for an item search paginated by _id",
 			item{ID: bson.ObjectIdHex("5addf533e81549de7696cb04"), Name: "test item", CreatedAt: time.Now()},
 			"_id",
+			[]string{"_id"},
 			false,
 			nil,
 			"FgAAAAdfaWQAWt31M-gVSd52lssEAA",
@@ -396,6 +399,7 @@ func TestGenerateCursor(t *testing.T) {
 			"return the generated cursor for an item search paginated by name",
 			item{ID: bson.ObjectIdHex("1addf533e81549de7696cb04"), Name: "test item 1", CreatedAt: time.Now()},
 			"name",
+			[]string{"name", "_id"},
 			true,
 			nil,
 			"LAAAAAJuYW1lAAwAAAB0ZXN0IGl0ZW0gMQAHX2lkABrd9TPoFUnedpbLBAA",
@@ -405,6 +409,7 @@ func TestGenerateCursor(t *testing.T) {
 			"errors when invalid result _id is set",
 			item{ID: "123", Name: "test item", CreatedAt: time.Now()},
 			"_id",
+			[]string{"_id"},
 			false,
 			nil,
 			"",
@@ -414,6 +419,7 @@ func TestGenerateCursor(t *testing.T) {
 			"errors when result is nil",
 			nil,
 			"_id",
+			[]string{"_id"},
 			false,
 			nil,
 			"",
@@ -423,6 +429,7 @@ func TestGenerateCursor(t *testing.T) {
 			"errors when paginated field not found and result is bson.Raw",
 			&[]bson.Raw{},
 			"creatorId",
+			[]string{"creatorId", "_id"},
 			false,
 			nil,
 			"",
@@ -432,6 +439,7 @@ func TestGenerateCursor(t *testing.T) {
 			"errors when encoding fails",
 			item{ID: bson.ObjectIdHex("1addf533e81549de7696cb04"), Name: "test item", CreatedAt: time.Now()},
 			"name",
+			[]string{"name"},
 			false,
 			func(cursorData bson.D) (string, error) {
 				return "", errors.New("error")
@@ -450,7 +458,7 @@ func TestGenerateCursor(t *testing.T) {
 				}()
 			}
 
-			cursor, err := generateCursor(tc.result, tc.paginatedField, tc.shouldSecondarySortOnID)
+			cursor, err := generateCursor(tc.result, tc.paginatedFields)
 			require.Equal(t, tc.expectedCursor, cursor)
 			require.Equal(t, tc.expectedErr, err)
 		})

--- a/mongo/find.go
+++ b/mongo/find.go
@@ -81,6 +81,9 @@ type (
 		// mongo can process this on the backend. Will default to 45 seconds, but should be set to an appropriate duration
 		// This parameter will also apply timeout of counting total results
 		Timeout time.Duration
+		// The names of multiple fields being paginated and sorted on
+		PaginatedFields []string
+		SortOrders      []int
 	}
 
 	// Cursor holds the pagination data about the find mongo query that was performed.
@@ -111,7 +114,12 @@ func (e *CursorError) Error() string {
 // BuildQueries builds the queries without executing them
 func BuildQueries(ctx context.Context, p FindParams) (queries []bson.M, sort bson.D, err error) {
 	p = ensureMandatoryParams(p)
-	shouldSecondarySortOnID := p.PaginatedField != "_id"
+	var numPaginatedFields int
+	if p.PaginatedFields != nil && len(p.PaginatedFields) > 0 {
+		numPaginatedFields = len(p.PaginatedFields)
+	} else {
+		numPaginatedFields = 1
+	}
 
 	if p.Collection == nil {
 		return []bson.M{}, nil, errors.New("Collection can't be nil")
@@ -121,24 +129,17 @@ func BuildQueries(ctx context.Context, p FindParams) (queries []bson.M, sort bso
 		return []bson.M{}, nil, errors.New("a limit of at least 1 is required")
 	}
 
-	nextCursorValues, err := parseCursor(p.Next, shouldSecondarySortOnID)
+	nextCursorValues, err := parseCursor(p.Next, numPaginatedFields)
 	if err != nil {
 		return []bson.M{}, nil, &CursorError{fmt.Errorf("next cursor parse failed: %s", err)}
 	}
 
-	previousCursorValues, err := parseCursor(p.Previous, shouldSecondarySortOnID)
+	previousCursorValues, err := parseCursor(p.Previous, numPaginatedFields)
 	if err != nil {
 		return []bson.M{}, nil, &CursorError{fmt.Errorf("previous cursor parse failed: %s", err)}
 	}
 
-	// Figure out the sort direction and comparison operator that will be used in the augmented query
-	sortAsc := (!p.SortAscending && p.Previous != "") || (p.SortAscending && p.Previous == "")
-	comparisonOp := "$gt"
-	sortDir := 1
-	if !sortAsc {
-		comparisonOp = "$lt"
-		sortDir = -1
-	}
+	comparisonOps := generateComparisonOps(p)
 
 	// Augment the specified find query with cursor data
 	queries = []bson.M{p.Query}
@@ -152,7 +153,7 @@ func BuildQueries(ctx context.Context, p FindParams) (queries []bson.M, sort bso
 			cursorValues = previousCursorValues
 		}
 		var cursorQuery bson.M
-		cursorQuery, err = mcpbson.GenerateCursorQuery(shouldSecondarySortOnID, p.PaginatedField, comparisonOp, cursorValues)
+		cursorQuery, err = mcpbson.GenerateCursorQuery(p.PaginatedFields, comparisonOps, cursorValues)
 		if err != nil {
 			return []bson.M{}, nil, err
 		}
@@ -160,10 +161,8 @@ func BuildQueries(ctx context.Context, p FindParams) (queries []bson.M, sort bso
 	}
 
 	// Setup the sort query
-	if shouldSecondarySortOnID {
-		sort = bson.D{{Key: p.PaginatedField, Value: sortDir}, {Key: "_id", Value: sortDir}}
-	} else {
-		sort = bson.D{{Key: "_id", Value: sortDir}}
+	for i := range p.PaginatedFields {
+		sort = append(sort, bson.E{Key: p.PaginatedFields[i], Value: p.SortOrders[i]})
 	}
 
 	return queries, sort, nil
@@ -177,7 +176,6 @@ func Find(ctx context.Context, p FindParams, results interface{}) (Cursor, error
 		return Cursor{}, errors.New("results can't be nil")
 	}
 	p = ensureMandatoryParams(p)
-	shouldSecondarySortOnID := p.PaginatedField != "_id"
 
 	// Compute total count of documents matching filter - only computed if CountTotal is True
 	var count int
@@ -229,7 +227,7 @@ func Find(ctx context.Context, p FindParams, results interface{}) (Cursor, error
 		// Generate the previous cursor
 		if hasPrevious {
 			firstResult := resultsVal.Index(0).Interface()
-			previousCursor, err = generateCursor(firstResult, p.PaginatedField, shouldSecondarySortOnID)
+			previousCursor, err = generateCursor(firstResult, p.PaginatedFields)
 			if err != nil {
 				return Cursor{}, fmt.Errorf("could not create a previous cursor: %s", err)
 			}
@@ -238,7 +236,7 @@ func Find(ctx context.Context, p FindParams, results interface{}) (Cursor, error
 		// Generate the next cursor
 		if hasNext {
 			lastResult := resultsVal.Index(resultsVal.Len() - 1).Interface()
-			nextCursor, err = generateCursor(lastResult, p.PaginatedField, shouldSecondarySortOnID)
+			nextCursor, err = generateCursor(lastResult, p.PaginatedFields)
 			if err != nil {
 				return Cursor{}, fmt.Errorf("could not create a next cursor: %s", err)
 			}
@@ -260,38 +258,68 @@ func Find(ctx context.Context, p FindParams, results interface{}) (Cursor, error
 	return cursor, nil
 }
 
+func generateComparisonOps(p FindParams) []string {
+	comparisonOps := make([]string, 0, len(p.SortOrders))
+	for i := range p.SortOrders {
+		// Figure out the sort direction and comparison operator that will be used in the augmented query
+		sortAsc := (p.SortOrders[i] == -1 && p.Previous != "") || (p.SortOrders[i] == 1 && p.Previous == "")
+		if sortAsc {
+			comparisonOps = append(comparisonOps, "$gt")
+			p.SortOrders[i] = 1
+		} else {
+			comparisonOps = append(comparisonOps, "$lt")
+			p.SortOrders[i] = -1
+		}
+	}
+	return comparisonOps
+}
+
 func ensureMandatoryParams(p FindParams) FindParams {
 	if p.PaginatedField == "" {
 		p.PaginatedField = "_id"
 		p.Collation = nil
 	}
-
+	if p.PaginatedFields == nil || len(p.PaginatedFields) == 0 {
+		if p.PaginatedField == "" {
+			p.PaginatedFields = []string{"_id"}
+			p.Collation = nil
+		} else {
+			p.PaginatedFields = []string{p.PaginatedField, "_id"}
+		}
+	}
+	if p.SortOrders == nil || len(p.SortOrders) == 0 {
+		p.SortOrders = []int{}
+		if p.SortAscending {
+			for i := 0; i < len(p.PaginatedFields); i++ {
+				p.SortOrders = append(p.SortOrders, 1)
+			}
+		} else {
+			for i := 0; i < len(p.PaginatedFields); i++ {
+				p.SortOrders = append(p.SortOrders, -1)
+			}
+		}
+	}
 	return p
 }
 
-var parseCursor = func(cursor string, shouldSecondarySortOnID bool) ([]interface{}, error) {
-	cursorValues := make([]interface{}, 0, 2)
+var parseCursor = func(cursor string, numPaginatedFields int) ([]interface{}, error) {
+	cursorValues := make([]interface{}, 0, numPaginatedFields)
 	if cursor != "" {
 		parsedCursor, err := decodeCursor(cursor)
 		if err != nil {
 			return nil, err
 		}
-		var id interface{}
-		if shouldSecondarySortOnID {
-			if len(parsedCursor) != 2 {
-				return nil, errors.New("expecting a cursor with two elements")
-			}
-			paginatedFieldValue := parsedCursor[0].Value
-			id = parsedCursor[1].Value
-			cursorValues = append(cursorValues, paginatedFieldValue)
-		} else {
-			if len(parsedCursor) != 1 {
+		if len(parsedCursor) != numPaginatedFields {
+			if numPaginatedFields == 1 {
 				return nil, errors.New("expecting a cursor with a single element")
 			}
-			id = parsedCursor[0].Value
+			return nil, fmt.Errorf("expecting a cursor with %d elements", numPaginatedFields)
 		}
-		cursorValues = append(cursorValues, id)
+		for _, obj := range parsedCursor {
+			cursorValues = append(cursorValues, obj.Value)
+		}
 	}
+
 	return cursorValues, nil
 }
 
@@ -355,7 +383,7 @@ func executeCursorQuery(ctx context.Context, c Collection, query []bson.M, sort 
 	return nil
 }
 
-func generateCursor(result interface{}, paginatedField string, shouldSecondarySortOnID bool) (string, error) {
+func generateCursor(result interface{}, paginatedFields []string) (string, error) {
 	if result == nil {
 		return "", fmt.Errorf("the specified result must be a non nil value")
 	}
@@ -383,14 +411,14 @@ func generateCursor(result interface{}, paginatedField string, shouldSecondarySo
 	if err != nil {
 		return "", err
 	}
-	paginatedFieldValue := recordAsMap[paginatedField]
 	// Set the cursor data
-	cursorData := make(bson.D, 0, 2)
-	cursorData = append(cursorData, bson.E{Key: paginatedField, Value: paginatedFieldValue})
-	if shouldSecondarySortOnID {
-		// Get the value of the ID field
-		id := recordAsMap["_id"]
-		cursorData = append(cursorData, bson.E{Key: "_id", Value: id})
+	cursorData := make(bson.D, 0, len(paginatedFields))
+	for i := range paginatedFields {
+		paginatedFieldValue := recordAsMap[paginatedFields[i]]
+		if paginatedFieldValue == nil {
+			return "", fmt.Errorf("paginated field %s not found", paginatedFields[i])
+		}
+		cursorData = append(cursorData, bson.E{Key: paginatedFields[i], Value: paginatedFieldValue})
 	}
 	// Encode the cursor data into a url safe string
 	cursor, err := encodeCursor(cursorData)

--- a/mongo/find.go
+++ b/mongo/find.go
@@ -81,9 +81,10 @@ type (
 		// mongo can process this on the backend. Will default to 45 seconds, but should be set to an appropriate duration
 		// This parameter will also apply timeout of counting total results
 		Timeout time.Duration
-		// The names of multiple fields being paginated and sorted on
+		// The names of multiple fields being paginated and sorted on. Takes precedence over PaginatedField
 		PaginatedFields []string
-		SortOrders      []int
+		// The sort orders corresponding to PaginatedFields. Each value must be either 1 or -1
+		SortOrders []int
 	}
 
 	// Cursor holds the pagination data about the find mongo query that was performed.
@@ -279,7 +280,7 @@ func ensureMandatoryParams(p FindParams) FindParams {
 		p.PaginatedField = "_id"
 		p.Collation = nil
 	}
-	if p.PaginatedFields == nil || len(p.PaginatedFields) == 0 {
+	if len(p.PaginatedFields) == 0 {
 		if p.PaginatedField == "_id" {
 			p.PaginatedFields = []string{"_id"}
 		} else {
@@ -289,7 +290,7 @@ func ensureMandatoryParams(p FindParams) FindParams {
 		p.PaginatedFields = append(p.PaginatedFields, "_id")
 		p.SortOrders = append(p.SortOrders, 1)
 	}
-	if p.SortOrders == nil || len(p.SortOrders) == 0 {
+	if len(p.SortOrders) == 0 {
 		p.SortOrders = []int{}
 		if p.SortAscending {
 			for i := 0; i < len(p.PaginatedFields); i++ {

--- a/mongo/find.go
+++ b/mongo/find.go
@@ -280,12 +280,14 @@ func ensureMandatoryParams(p FindParams) FindParams {
 		p.Collation = nil
 	}
 	if p.PaginatedFields == nil || len(p.PaginatedFields) == 0 {
-		if p.PaginatedField == "" {
+		if p.PaginatedField == "_id" {
 			p.PaginatedFields = []string{"_id"}
-			p.Collation = nil
 		} else {
 			p.PaginatedFields = []string{p.PaginatedField, "_id"}
 		}
+	} else if p.PaginatedFields[len(p.PaginatedFields)-1] != "_id" {
+		p.PaginatedFields = append(p.PaginatedFields, "_id")
+		p.SortOrders = append(p.SortOrders, 1)
 	}
 	if p.SortOrders == nil || len(p.SortOrders) == 0 {
 		p.SortOrders = []int{}

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -8,4 +8,4 @@ set -eu
 ARGS=$1
 
 # The idiomatic way to disable test caching explicitly is to use -count=1
-go test -count=1 -race -v -gcflags="-N -l" ./test/integration/... $ARGS
+go test -count=1 -race -v ./test/integration/... $ARGS

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -8,4 +8,4 @@ set -eu
 ARGS=$1
 
 # The idiomatic way to disable test caching explicitly is to use -count=1
-go test -count=1 -race -v ./test/integration/... $ARGS
+go test -count=1 -race -v -gcflags="-N -l" ./test/integration/... $ARGS

--- a/test/integration/mgo_items_store.go
+++ b/test/integration/mgo_items_store.go
@@ -13,6 +13,7 @@ type (
 	Item struct {
 		ID        bson.ObjectId `bson:"_id"`
 		Name      string        `bson:"name"`
+		Data      string        `bson:"data"`
 		CreatedAt time.Time     `bson:"createdAt"`
 	}
 
@@ -23,6 +24,7 @@ type (
 		Find(query interface{}, next string, previous string, limit int, sortAscending bool, paginatedField string, collation mgo.Collation) ([]*Item, mongocursorpagination.Cursor, error)
 		FindBSONRaw(query interface{}, next string, previous string, limit int, sortAscending bool, paginatedField string, collation mgo.Collation) ([]bson.Raw, mongocursorpagination.Cursor, error)
 		EnsureIndices() error
+		FindMultiplePaginatedFields(query interface{}, next string, previous string, limit int, sortOrders []int, paginatedFields []string, collation mgo.Collation) ([]*Item, mongocursorpagination.Cursor, error)
 	}
 
 	mgoStore struct {
@@ -48,6 +50,12 @@ func (m *mgoStore) Create(c *Item) (*Item, error) {
 func (m *mgoStore) Find(query interface{}, next string, previous string, limit int, sortAscending bool, paginatedField string, collation mgo.Collation) ([]*Item, mongocursorpagination.Cursor, error) {
 	var items []*Item
 	cursor, err := m.find(query, next, previous, limit, sortAscending, paginatedField, collation, &items)
+	return items, cursor, err
+}
+
+func (m *mgoStore) FindMultiplePaginatedFields(query interface{}, next string, previous string, limit int, sortOrders []int, paginatedFields []string, collation mgo.Collation) ([]*Item, mongocursorpagination.Cursor, error) {
+	var items []*Item
+	cursor, err := m.findMultiplePaginatedFields(query, next, previous, limit, sortOrders, paginatedFields, collation, &items)
 	return items, cursor, err
 }
 
@@ -81,12 +89,36 @@ func (m *mgoStore) find(query interface{}, next string, previous string, limit i
 	return cursor, err
 }
 
+func (m *mgoStore) findMultiplePaginatedFields(query interface{}, next string, previous string, limit int, sortOrders []int, paginatedFields []string, collation mgo.Collation, results interface{}) (mongocursorpagination.Cursor, error) {
+	bsonQuery := query.(bson.M)
+	fp := mongocursorpagination.FindParams{
+		DB:              m.col.Database,
+		CollectionName:  m.col.Name,
+		Query:           bsonQuery,
+		Limit:           limit,
+		SortOrders:      sortOrders,
+		PaginatedFields: paginatedFields,
+		Collation:       &collation,
+		Next:            next,
+		Previous:        previous,
+		CountTotal:      true,
+	}
+	c, err := mongocursorpagination.Find(fp, results)
+	cursor := mongocursorpagination.Cursor{
+		Previous:    c.Previous,
+		Next:        c.Next,
+		HasPrevious: c.HasPrevious,
+		HasNext:     c.HasNext,
+	}
+	return cursor, err
+}
+
 // EnsureIndices creates indices and returns any error
 func (m *mgoStore) EnsureIndices() error {
 	err := m.col.EnsureIndex(mgo.Index{
 		Name: "cover_find_by_name",
 		// _id is required in the index' key as we secondary sort on _id when the paginated field is not _id
-		Key:    []string{"name", "_id"},
+		Key:    []string{"name", "data", "_id"},
 		Unique: false,
 		Collation: &mgo.Collation{
 			Locale:   "en",

--- a/test/integration/mgo_items_store_test.go
+++ b/test/integration/mgo_items_store_test.go
@@ -24,11 +24,12 @@ func newStore(t *testing.T) Store {
 	return store
 }
 
-func createItem(t *testing.T, store Store, name string) *Item {
+func createItem(t *testing.T, store Store, name string, data string) *Item {
 	t.Helper()
 	item := &Item{
 		ID:        "",
 		Name:      name,
+		Data:      data,
 		CreatedAt: time.Now(),
 	}
 	item, err := store.Create(item)
@@ -49,10 +50,10 @@ func TestCollectionsFindManyPagination(t *testing.T) {
 	require.False(t, cursor.HasNext)
 	require.False(t, cursor.HasPrevious)
 
-	item4 := createItem(t, store, "test item 4")
-	item1 := createItem(t, store, "test item 1")
-	item3 := createItem(t, store, "test item 3")
-	item2 := createItem(t, store, "test item 2")
+	item4 := createItem(t, store, "test item 4", "")
+	item1 := createItem(t, store, "test item 1", "")
+	item3 := createItem(t, store, "test item 3", "")
+	item2 := createItem(t, store, "test item 2", "")
 
 	// Get first page of search for items
 	foundItems, cursor, err = store.Find(searchQuery, "", "", 2, true, "name", englishCollation)
@@ -99,10 +100,10 @@ func TestFindManyPaginationWithDuplicatedPaginatedField(t *testing.T) {
 	require.False(t, cursor.HasNext)
 	require.False(t, cursor.HasPrevious)
 
-	item1 := createItem(t, store, "duplicated name")
-	item2 := createItem(t, store, "duplicated name")
-	item3 := createItem(t, store, "duplicated name")
-	item4 := createItem(t, store, "duplicated name")
+	item1 := createItem(t, store, "duplicated name", "")
+	item2 := createItem(t, store, "duplicated name", "")
+	item3 := createItem(t, store, "duplicated name", "")
+	item4 := createItem(t, store, "duplicated name", "")
 
 	// Get first page of search for items
 	foundItems, cursor, err = store.Find(searchQuery, "", "", 2, false, "name", englishCollation)
@@ -156,10 +157,10 @@ func TestMgoPaginationBSONRaw(t *testing.T) {
 	searchQuery := bson.M{"name": bson.RegEx{Pattern: "test item.*", Options: "i"}}
 	englishCollation := mgo.Collation{Locale: "en", Strength: 3}
 
-	item1 := createItem(t, store, "test item 1")
-	item2 := createItem(t, store, "test item 2")
-	createItem(t, store, "test item 3")
-	createItem(t, store, "test item 4")
+	item1 := createItem(t, store, "test item 1", "")
+	item2 := createItem(t, store, "test item 2", "")
+	createItem(t, store, "test item 3", "")
+	createItem(t, store, "test item 4", "")
 
 	foundItems, cursor, err := store.FindBSONRaw(searchQuery, "", "", 2, true, "name", englishCollation)
 	require.NoError(t, err)
@@ -176,6 +177,65 @@ func TestMgoPaginationBSONRaw(t *testing.T) {
 	require.Equal(t, item1.ID, result0.ID)
 	require.Equal(t, item2.ID, result1.ID)
 
+	// Cleanup
+	err = store.RemoveAll()
+	require.NoError(t, err)
+}
+
+func TestCollectionFindMultiplePaginatedFields(t *testing.T) {
+	store := newStore(t)
+
+	searchQuery := bson.M{"name": bson.RegEx{Pattern: "test item.*", Options: "i"}}
+	englishCollation := mgo.Collation{Locale: "en", Strength: 3}
+
+	// Get empty array when no items created
+	foundItems, cursor, err := store.Find(searchQuery, "", "", 4, true, "name", englishCollation)
+	require.NoError(t, err)
+	require.Empty(t, foundItems)
+	require.False(t, cursor.HasNext)
+	require.False(t, cursor.HasPrevious)
+
+	item1 := createItem(t, store, "test item 1", "5")
+	item2 := createItem(t, store, "test item 2", "5")
+	item3 := createItem(t, store, "test item 3", "5")
+	item4 := createItem(t, store, "test item 4", "5")
+	item5 := createItem(t, store, "test item 5", "4")
+	item6 := createItem(t, store, "test item 6", "4")
+	item7 := createItem(t, store, "test item 7", "3")
+	item8 := createItem(t, store, "test item 8", "2")
+
+	// Get first page of search for items
+	foundItems, cursor, err = store.FindMultiplePaginatedFields(searchQuery, "", "", 4, []int{1, -1}, []string{"data", "name"}, englishCollation)
+	require.NoError(t, err)
+	require.Equal(t, 4, len(foundItems))
+	require.True(t, cursor.HasNext)
+	require.False(t, cursor.HasPrevious)
+	require.Equal(t, item8.ID, foundItems[0].ID)
+	require.Equal(t, item7.ID, foundItems[1].ID)
+	require.Equal(t, item6.ID, foundItems[2].ID)
+	require.Equal(t, item5.ID, foundItems[3].ID)
+
+	// Get 2nd page of search for items
+	foundItems, cursor, err = store.FindMultiplePaginatedFields(searchQuery, cursor.Next, "", 4, []int{1, -1}, []string{"data", "name"}, englishCollation)
+	require.NoError(t, err)
+	require.Equal(t, 4, len(foundItems))
+	require.False(t, cursor.HasNext)
+	require.True(t, cursor.HasPrevious)
+	require.Equal(t, item4.ID, foundItems[0].ID)
+	require.Equal(t, item3.ID, foundItems[1].ID)
+	require.Equal(t, item2.ID, foundItems[2].ID)
+	require.Equal(t, item1.ID, foundItems[3].ID)
+
+	// Get previous page of search for items
+	foundItems, cursor, err = store.FindMultiplePaginatedFields(searchQuery, "", cursor.Previous, 4, []int{1, -1}, []string{"data", "name"}, englishCollation)
+	require.NoError(t, err)
+	require.Equal(t, 4, len(foundItems))
+	require.True(t, cursor.HasNext)
+	require.False(t, cursor.HasPrevious)
+	require.Equal(t, item8.ID, foundItems[0].ID)
+	require.Equal(t, item7.ID, foundItems[1].ID)
+	require.Equal(t, item6.ID, foundItems[2].ID)
+	require.Equal(t, item5.ID, foundItems[3].ID)
 	// Cleanup
 	err = store.RemoveAll()
 	require.NoError(t, err)

--- a/test/integration/mgo_items_store_test.go
+++ b/test/integration/mgo_items_store_test.go
@@ -189,7 +189,7 @@ func TestCollectionFindMultiplePaginatedFields(t *testing.T) {
 	englishCollation := mgo.Collation{Locale: "en", Strength: 3}
 
 	// Get empty array when no items created
-	foundItems, cursor, err := store.Find(searchQuery, "", "", 4, true, "name", englishCollation)
+	foundItems, cursor, err := store.FindMultiplePaginatedFields(searchQuery, "", "", 4, []int{1, -1}, []string{"data", "name"}, englishCollation)
 	require.NoError(t, err)
 	require.Empty(t, foundItems)
 	require.False(t, cursor.HasNext)

--- a/test/integration/mongo_items_store.go
+++ b/test/integration/mongo_items_store.go
@@ -15,6 +15,7 @@ type (
 	MongoItem struct {
 		ID        primitive.ObjectID `bson:"_id"`
 		Name      string             `bson:"name"`
+		Data      string             `bson:"data"`
 		CreatedAt time.Time          `bson:"createdAt"`
 	}
 
@@ -23,6 +24,7 @@ type (
 		RemoveAll(context.Context) error
 		Find(ctx context.Context, query interface{}, next string, previous string, limit int64, sortAscending bool, paginatedField string, collation *options.Collation, hint interface{}, projection interface{}) ([]*MongoItem, mongocursorpagination.Cursor, error)
 		FindBSONRaw(ctx context.Context, query interface{}, next string, previous string, limit int64, sortAscending bool, paginatedField string, collation *options.Collation, hint interface{}, projection interface{}) ([]bson.Raw, mongocursorpagination.Cursor, error)
+		FindMultiplePaginatedFields(ctx context.Context, query interface{}, next string, previous string, limit int64, sortOrders []int, paginatedFields []string, collation *options.Collation, hint interface{}, projection interface{}) ([]*MongoItem, mongocursorpagination.Cursor, error)
 	}
 
 	mongoStore struct {
@@ -76,6 +78,12 @@ func (m *mongoStore) Find(ctx context.Context, query interface{}, next string, p
 	return items, cursor, err
 }
 
+func (m *mongoStore) FindMultiplePaginatedFields(ctx context.Context, query interface{}, next string, previous string, limit int64, sortOrders []int, paginatedFields []string, collation *options.Collation, hint interface{}, projection interface{}) ([]*MongoItem, mongocursorpagination.Cursor, error) {
+	var items []*MongoItem
+	cursor, err := m.mongoFindMultiplePaginatedFields(ctx, query, next, previous, limit, sortOrders, paginatedFields, collation, hint, projection, &items)
+	return items, cursor, err
+}
+
 func (m *mongoStore) FindBSONRaw(ctx context.Context, query interface{}, next string, previous string, limit int64, sortAscending bool, paginatedField string, collation *options.Collation, hint interface{}, projection interface{}) ([]bson.Raw, mongocursorpagination.Cursor, error) {
 	var items []bson.Raw
 	cursor, err := m.mongoFind(ctx, query, next, previous, limit, sortAscending, paginatedField, collation, hint, projection, &items)
@@ -96,6 +104,31 @@ func (m *mongoStore) mongoFind(ctx context.Context, query interface{}, next stri
 		CountTotal:     true,
 		Hint:           hint,
 		Projection:     projection,
+	}
+	c, err := mongocursorpagination.Find(ctx, fp, results)
+	cursor := mongocursorpagination.Cursor{
+		Previous:    c.Previous,
+		Next:        c.Next,
+		HasPrevious: c.HasPrevious,
+		HasNext:     c.HasNext,
+	}
+	return cursor, err
+}
+
+func (m *mongoStore) mongoFindMultiplePaginatedFields(ctx context.Context, query interface{}, next string, previous string, limit int64, sortOrders []int, paginatedFields []string, collation *options.Collation, hint interface{}, projection interface{}, results interface{}) (mongocursorpagination.Cursor, error) {
+	bsonQuery := query.(bson.M)
+	fp := mongocursorpagination.FindParams{
+		Collection:      m.col,
+		Query:           bsonQuery,
+		Limit:           limit,
+		SortOrders:      sortOrders,
+		PaginatedFields: paginatedFields,
+		Collation:       collation,
+		Next:            next,
+		Previous:        previous,
+		CountTotal:      true,
+		Hint:            hint,
+		Projection:      projection,
 	}
 	c, err := mongocursorpagination.Find(ctx, fp, results)
 	cursor := mongocursorpagination.Cursor{

--- a/test/integration/mongo_items_store_test.go
+++ b/test/integration/mongo_items_store_test.go
@@ -251,9 +251,8 @@ func TestMongoProjection(t *testing.T) {
 	_ = createMongoItem(t, store, "test item 1", "")
 
 	searchQuery := bson.M{}
-	projection := bson.D{
-		{Key: "_id", Value: 0}, // Do not return ID
-		{Key: "name", Value: 1},
+	projection := bson.D{bson.E{Key: "_id", Value: 0}, // Do not return ID
+		bson.E{Key: "name", Value: 1},
 	}
 
 	foundItems, _, err := store.FindBSONRaw(context.Background(), searchQuery, "", "", 2, true, "name", nil, nil, projection)
@@ -278,13 +277,13 @@ func TestMongoHint(t *testing.T) {
 	_, _, err := store.Find(context.Background(), searchQuery, "", "", 10, true, "_id", nil, "indexName_id", nil)
 	require.True(t, errors.As(err, &mongo.CommandError{}), "non existing index by name should result in a command error")
 
-	_, _, err = store.Find(context.Background(), searchQuery, "", "", 10, true, "_id", nil, bson.D{{Key: "created", Value: 1}}, nil)
+	_, _, err = store.Find(context.Background(), searchQuery, "", "", 10, true, "_id", nil, bson.D{bson.E{Key: "created", Value: 1}}, nil)
 	require.True(t, errors.As(err, &mongo.CommandError{}), "non existing index by specification document should result in a command error")
 
 	_, _, err = store.Find(context.Background(), searchQuery, "", "", 10, true, "_id", nil, "_id_", nil)
 	require.NoError(t, err, "hinting the default _id index by name should succeed")
 
-	_, _, err = store.Find(context.Background(), searchQuery, "", "", 10, true, "_id", nil, bson.D{{Key: "_id", Value: 1}}, nil)
+	_, _, err = store.Find(context.Background(), searchQuery, "", "", 10, true, "_id", nil, bson.D{bson.E{Key: "_id", Value: 1}}, nil)
 	require.NoError(t, err, "hinting the default _id index by specification document should succeed")
 
 	// Cleanup

--- a/test/integration/mongo_items_store_test.go
+++ b/test/integration/mongo_items_store_test.go
@@ -37,11 +37,12 @@ func newMongoCollection(t *testing.T) *mongoCollectionWrapper {
 	return &col
 }
 
-func createMongoItem(t *testing.T, mongoStore MongoStore, name string) *MongoItem {
+func createMongoItem(t *testing.T, mongoStore MongoStore, name string, data string) *MongoItem {
 	t.Helper()
 	item := &MongoItem{
 		ID:        primitive.NewObjectID(),
 		Name:      name,
+		Data:      data,
 		CreatedAt: time.Now(),
 	}
 	item, err := mongoStore.Create(context.Background(), item)
@@ -61,10 +62,10 @@ func TestMongoFindManyPagination(t *testing.T) {
 	require.False(t, cursor.HasNext)
 	require.False(t, cursor.HasPrevious)
 
-	item4 := createMongoItem(t, store, "test item 4")
-	item1 := createMongoItem(t, store, "test item 1")
-	item3 := createMongoItem(t, store, "test item 3")
-	item2 := createMongoItem(t, store, "test item 2")
+	item4 := createMongoItem(t, store, "test item 4", "")
+	item1 := createMongoItem(t, store, "test item 1", "")
+	item3 := createMongoItem(t, store, "test item 3", "")
+	item2 := createMongoItem(t, store, "test item 2", "")
 
 	// Get first page of search for items
 	foundItems, cursor, err = store.Find(context.Background(), searchQuery, "", "", 2, true, "name", &englishCollation, nil, nil)
@@ -103,8 +104,8 @@ func TestPaginationWithoutPaginatedField(t *testing.T) {
 	store := newMongoStore(t)
 	searchQuery := bson.M{"name": primitive.Regex{Pattern: fmt.Sprintf("%s.*", itemNamePrefix)}}
 
-	item1 := createMongoItem(t, store, fmt.Sprintf("%s-1", itemNamePrefix))
-	item2 := createMongoItem(t, store, fmt.Sprintf("%s-2", itemNamePrefix))
+	item1 := createMongoItem(t, store, fmt.Sprintf("%s-1", itemNamePrefix), "")
+	item2 := createMongoItem(t, store, fmt.Sprintf("%s-2", itemNamePrefix), "")
 
 	// Call Find without paginatedField argument.
 	foundItems, cursor, err := store.Find(context.Background(), searchQuery, "", "", 1, true, "", &options.Collation{}, nil, nil)
@@ -112,7 +113,6 @@ func TestPaginationWithoutPaginatedField(t *testing.T) {
 	require.Len(t, foundItems, 1)
 	require.Equal(t, item1.Name, foundItems[0].Name)
 	require.True(t, cursor.HasNext)
-
 	// Validate that cursor.Next works as expected.
 	foundItems, cursor, err = store.Find(context.Background(), searchQuery, cursor.Next, "", 1, true, "", &options.Collation{}, nil, nil)
 	require.NoError(t, err)
@@ -141,10 +141,10 @@ func TestMongoPaginationBSONRaw(t *testing.T) {
 	searchQuery := bson.M{"name": primitive.Regex{Pattern: "test item.*", Options: "i"}}
 	englishCollation := options.Collation{Locale: "en", Strength: 3}
 
-	item1 := createMongoItem(t, store, "test item 1")
-	item2 := createMongoItem(t, store, "test item 2")
-	createMongoItem(t, store, "test item 3")
-	createMongoItem(t, store, "test item 4")
+	item1 := createMongoItem(t, store, "test item 1", "")
+	item2 := createMongoItem(t, store, "test item 2", "")
+	createMongoItem(t, store, "test item 3", "")
+	createMongoItem(t, store, "test item 4", "")
 
 	foundItems, cursor, err := store.FindBSONRaw(context.Background(), searchQuery, "", "", 2, true, "name", &englishCollation, nil, nil)
 	require.NoError(t, err)
@@ -247,8 +247,8 @@ func TestMongoBuildPaginatedQueries(t *testing.T) {
 func TestMongoProjection(t *testing.T) {
 	store := newMongoStore(t)
 
-	_ = createMongoItem(t, store, "test item 0")
-	_ = createMongoItem(t, store, "test item 1")
+	_ = createMongoItem(t, store, "test item 0", "")
+	_ = createMongoItem(t, store, "test item 1", "")
 
 	searchQuery := bson.M{}
 	projection := bson.D{
@@ -272,7 +272,7 @@ func TestMongoHint(t *testing.T) {
 	searchQuery := bson.M{}
 
 	for _, c := range "abcdefg" {
-		_ = createMongoItem(t, store, string(c))
+		_ = createMongoItem(t, store, string(c), "")
 	}
 
 	_, _, err := store.Find(context.Background(), searchQuery, "", "", 10, true, "_id", nil, "indexName_id", nil)
@@ -296,4 +296,62 @@ func encodeCursor(t *testing.T, cursorData bson.D) string {
 	data, err := bson.Marshal(cursorData)
 	require.NoError(t, err, "invalid cursorData given to encodeCursor")
 	return base64.RawURLEncoding.EncodeToString(data)
+}
+
+func TestMongoFindMultiplePaginatedFields(t *testing.T) {
+	store := newMongoStore(t)
+	searchQuery := bson.M{"name": primitive.Regex{Pattern: "test item.*", Options: "i"}}
+	englishCollation := options.Collation{Locale: "en", Strength: 3}
+
+	foundItems, cursor, err := store.Find(context.Background(), searchQuery, "", "", 4, true, "name", &englishCollation, nil, nil)
+	require.NoError(t, err)
+	require.Empty(t, foundItems)
+	require.False(t, cursor.HasNext)
+	require.False(t, cursor.HasPrevious)
+
+	item1 := createMongoItem(t, store, "test item 1", "5")
+	item2 := createMongoItem(t, store, "test item 2", "5")
+	item3 := createMongoItem(t, store, "test item 3", "5")
+	item4 := createMongoItem(t, store, "test item 4", "5")
+	item5 := createMongoItem(t, store, "test item 5", "4")
+	item6 := createMongoItem(t, store, "test item 6", "4")
+	item7 := createMongoItem(t, store, "test item 7", "3")
+	item8 := createMongoItem(t, store, "test item 8", "2")
+
+	// Get first page of search for items
+	foundItems, cursor, err = store.FindMultiplePaginatedFields(context.Background(), searchQuery, "", "", 4, []int{1, -1}, []string{"data", "name"}, &englishCollation, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, 4, len(foundItems))
+	require.True(t, cursor.HasNext)
+	require.False(t, cursor.HasPrevious)
+	require.Equal(t, item8.ID, foundItems[0].ID)
+	require.Equal(t, item7.ID, foundItems[1].ID)
+	require.Equal(t, item6.ID, foundItems[2].ID)
+	require.Equal(t, item5.ID, foundItems[3].ID)
+
+	// Get 2nd page of search for items
+	foundItems, cursor, err = store.FindMultiplePaginatedFields(context.Background(), searchQuery, cursor.Next, "", 4, []int{1, -1}, []string{"data", "name"}, &englishCollation, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, 4, len(foundItems))
+	require.False(t, cursor.HasNext)
+	require.True(t, cursor.HasPrevious)
+	require.Equal(t, item4.ID, foundItems[0].ID)
+	require.Equal(t, item3.ID, foundItems[1].ID)
+	require.Equal(t, item2.ID, foundItems[2].ID)
+	require.Equal(t, item1.ID, foundItems[3].ID)
+
+	// Get previous page of search for items
+	foundItems, cursor, err = store.FindMultiplePaginatedFields(context.Background(), searchQuery, "", cursor.Previous, 4, []int{1, -1}, []string{"data", "name"}, &englishCollation, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, 4, len(foundItems))
+	require.True(t, cursor.HasNext)
+	require.False(t, cursor.HasPrevious)
+	require.Equal(t, item8.ID, foundItems[0].ID)
+	require.Equal(t, item7.ID, foundItems[1].ID)
+	require.Equal(t, item6.ID, foundItems[2].ID)
+	require.Equal(t, item5.ID, foundItems[3].ID)
+
+	// Cleanup
+	err = store.RemoveAll(context.Background())
+	require.NoError(t, err)
 }


### PR DESCRIPTION
added two optional parameters `paginatedFields: []string` and `sortOrders: []int`

`ensureMandatoryParameters` makes sure that both slices are initialized and the last paginated field is `_id`

`bson.GenerateCursorQuery` generates queries in the format
```
{"$and": {
	{"$or": {
		{paginatedField[0]: {comparisonOps[0]: cursorFieldValues[0]}},
		{"$and": {
			{paginatedField[0]: {comparisonOps[0]+"e": cursorFieldValues[0]}},
			{"_id": {comparisonOps[0]: cursorFieldValues[-1]}}}}}},
	{"$or": {
		{paginatedField[1]: {comparisonOps[1]: cursorFieldValues[1]}},
		{"$and": {
			{paginatedField[1]: {comparisonOps[1]+"e": cursorFieldValues[1]}},
			{"_id": {comparisonOps[1]: cursorFieldValues[-1]}}}}}},
	...
	}
}
```