### PR TITLE
fix: invalid paginated field

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ default-job-init: &default-job-init
   environment:
     DOCKER_BUILDKIT: "1"
 remote_docker_version: &remote_docker_version
-    version: 20.10.6
+    version: docker24
 load-test-docker-image: &load-test-docker-image
     name: Load test docker image
     command: |


### PR DESCRIPTION
Handle invalid paginated fields
- mongo ignores invalid fields, so result used in `generateCursor()` will not include invalid fields
- parseCursor will update PaginatedFields and SortOrders, keeping only the values that are present in the cursor